### PR TITLE
Fix ball paddle collision

### DIFF
--- a/lib/ball.js
+++ b/lib/ball.js
@@ -99,12 +99,11 @@ let ball = class Ball {
     } else {
       ball.xSpeed *= -1;
     }
-  };
-
+  }
   checkPaddles(paddles) {
     let self = this;
     paddles.forEach(function(paddle) {
-      if (self.x + self.radius > paddle.x && self.x - self.radius < paddle.right() && self.y + self.radius > paddle.y && self.y - self.radius < paddle.bottom()) {
+      if (self.right() > paddle.x && self.left() < paddle.right() && self.bottom() > paddle.y && self.top() < paddle.bottom()) {
         if (paddle.vertical) {
           self.xSpeed *= -1;
         } else {
@@ -112,7 +111,19 @@ let ball = class Ball {
         }
       }
     });
-  };
+  }
+  top() {
+    return this.y - this.radius;
+  }
+  bottom() {
+    return this.y + this.radius;
+  }
+  left() {
+    return this.x - this.radius;
+  }
+  right() {
+    return this.x + this.radius;
+  }
 }
 
 function clamp(val, min, max) {

--- a/lib/ball.js
+++ b/lib/ball.js
@@ -104,7 +104,7 @@ let ball = class Ball {
   checkPaddles(paddles) {
     let self = this;
     paddles.forEach(function(paddle) {
-      if (self.x > paddle.x && self.x < paddle.right() && self.y > paddle.y && self.y < paddle.bottom()) {
+      if (self.x + self.radius > paddle.x && self.x - self.radius < paddle.right() && self.y + self.radius > paddle.y && self.y - self.radius < paddle.bottom()) {
         if (paddle.vertical) {
           self.xSpeed *= -1;
         } else {

--- a/test/ball-test.js
+++ b/test/ball-test.js
@@ -168,6 +168,7 @@ describe('Ball', function() {
       ball.whichSide(ball, block);
       assert.equal(ball.ySpeed, -speed);
     });
+
     it('reverses ySpeed when colliding with bottom', function () {
       let ball = new Ball(xy+radius, xy+radius-1, radius, speed, speed);
       let block = new Block(xy, xy, blockSize, blockSize, 'black');
@@ -175,6 +176,7 @@ describe('Ball', function() {
       ball.whichSide(ball, block);
       assert.equal(ball.ySpeed, -speed);
     });
+
     it('reverses xSpeed when colliding with left', function () {
       let ball = new Ball(xy-radius+1, xy+radius, radius, speed, speed);
       let block = new Block(xy, xy, blockSize, blockSize, 'black');
@@ -182,6 +184,7 @@ describe('Ball', function() {
       ball.whichSide(ball, block);
       assert.equal(ball.xSpeed, -speed);
     });
+
     it('reverses xSpeed when colliding with right', function () {
       let ball = new Ball(xy+radius-1, xy+radius, radius, speed, speed);
       let block = new Block(xy, xy, blockSize, blockSize, 'black');
@@ -189,5 +192,41 @@ describe('Ball', function() {
       ball.whichSide(ball, block);
       assert.equal(ball.xSpeed, -speed);
     });
-  })
+  });
+
+  describe('#top', function() {
+
+    it('returns the center y coordinate minus the radius', function() {
+      let ball = new Ball(50, 50, 10, 0, 0)
+      let top = 40;
+      assert.equal(ball.top(), top);
+    });
+  });
+
+  describe('#bottom', function() {
+
+    it('returns the center y coordinate plus the radius', function() {
+      let ball = new Ball(50, 50, 10, 0, 0)
+      let bottom = 60;
+      assert.equal(ball.bottom(), bottom);
+    });
+  });
+
+  describe('#left', function() {
+
+    it('returns the center x coordinate minus the radius', function() {
+      let ball = new Ball(50, 50, 10, 0, 0)
+      let left = 40;
+      assert.equal(ball.left(), left);
+    });
+  });
+
+  describe('#right', function() {
+
+    it('returns the center x coordinate plus the radius', function() {
+      let ball = new Ball(50, 50, 10, 0, 0)
+      let right = 60;
+      assert.equal(ball.right(), right);
+    });
+  });
 });


### PR DESCRIPTION
Fixed paddle collision.

Previously, ball would bounce off paddle based on center of ball impact. Now uses the center plus the radius for the top, left, right, and bottom of the ball to calculate the collision.

Added tests for top, left, right, and bottom functions in ball.
